### PR TITLE
[Bug/#21] 문자열이 겹치지 않게 수정

### DIFF
--- a/app/src/main/res/values/text_styles.xml
+++ b/app/src/main/res/values/text_styles.xml
@@ -4,7 +4,6 @@
 
     <style name="marry_text">
         <item name="android:fontFamily">@font/nanum_square_neo</item>
-        <item name="android:letterSpacing">-0.4</item>
     </style>
 
     <style name="large_title" parent="marry_text">


### PR DESCRIPTION
#### close #21

### ✏️ 개요

문자열이 겹쳐 보여서 `<item name="android:letterSpacing">-0.4</item>` 이 코드 지움.
