### PR TITLE
[Feat/#24] MeryAppBar 구현

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -5,6 +5,7 @@ plugins {
     alias(libs.plugins.jetbrainsKotlinAndroid)
     alias(libs.plugins.hilt)
     alias(libs.plugins.ksp)
+    kotlin("kapt")
 }
 
 val properties = Properties().apply {

--- a/app/src/main/java/com/abloom/mery/presentation/common/util/IntExt.kt
+++ b/app/src/main/java/com/abloom/mery/presentation/common/util/IntExt.kt
@@ -1,0 +1,7 @@
+package com.abloom.mery.presentation.common.util
+
+import android.content.res.Resources
+import kotlin.math.roundToInt
+
+val Int.dp: Int
+    get() = (this * Resources.getSystem().displayMetrics.density).roundToInt()

--- a/app/src/main/java/com/abloom/mery/presentation/common/view/MeryAppBar.kt
+++ b/app/src/main/java/com/abloom/mery/presentation/common/view/MeryAppBar.kt
@@ -79,56 +79,48 @@ class MeryAppBar(
                     ?: throw IllegalArgumentException("MeryAppBar의 navigationIcon과 navigationText 둘 다 null이면 안됩니다.")
     }
 
-    private fun createNavigationIconView(drawable: Drawable): ImageView {
-        val view = ImageView(context)
-        view.id = generateViewId()
-        view.layoutParams = LayoutParams(NAVIGATION_ICON_BUTTON_SIZE, NAVIGATION_ICON_BUTTON_SIZE)
-        view.setImageDrawable(drawable)
-        return view
+    private fun createNavigationIconView(drawable: Drawable) = ImageView(context).apply {
+        id = generateViewId()
+        layoutParams = LayoutParams(NAVIGATION_ICON_BUTTON_SIZE, NAVIGATION_ICON_BUTTON_SIZE)
+        setImageDrawable(drawable)
     }
 
-    private fun createNavigationTextView(text: CharSequence): TextView {
-        val view = TextView(context)
-        view.id = generateViewId()
-        view.text = text
-        view.setTextAppearance(R.style.callout)
-        view.typeface = ResourcesCompat.getFont(context, R.font.nanum_square_neo_bold)
+    private fun createNavigationTextView(text: CharSequence) = TextView(context).apply {
+        id = generateViewId()
+        this.text = text
+        setTextAppearance(R.style.callout)
+        typeface = ResourcesCompat.getFont(context, R.font.nanum_square_neo_bold)
         val color = ContextCompat.getColor(context, R.color.primary_08)
-        view.setTextColor(color)
-        view.setPadding(
+        setTextColor(color)
+        setPadding(
             BUTTON_HORIZONTAL_PADDING,
             BUTTON_VERTICAL_PADDING,
             BUTTON_HORIZONTAL_PADDING,
             BUTTON_VERTICAL_PADDING
         )
-        return view
     }
 
-    private fun createTitleView(text: CharSequence): TextView {
-        val view = TextView(context)
-        view.id = generateViewId()
-        view.text = text
-        view.setTextAppearance(R.style.body)
-        view.typeface = ResourcesCompat.getFont(context, R.font.nanum_square_neo_bold)
-        view.setTextColor(Color.BLACK)
-        return view
+    private fun createTitleView(text: CharSequence) = TextView(context).apply {
+        id = generateViewId()
+        this.text = text
+        setTextAppearance(R.style.body)
+        typeface = ResourcesCompat.getFont(context, R.font.nanum_square_neo_bold)
+        setTextColor(Color.BLACK)
     }
 
-    private fun createActionView(text: CharSequence): TextView {
-        val view = TextView(context)
-        view.id = generateViewId()
-        view.text = text
-        view.setTextAppearance(R.style.callout)
-        view.typeface = ResourcesCompat.getFont(context, R.font.nanum_square_neo_bold)
+    private fun createActionView(text: CharSequence) = TextView(context).apply {
+        id = generateViewId()
+        this.text = text
+        setTextAppearance(R.style.callout)
+        typeface = ResourcesCompat.getFont(context, R.font.nanum_square_neo_bold)
         val colors = ContextCompat.getColorStateList(context, R.color.text_button)
-        view.setTextColor(colors)
-        view.setPadding(
+        setTextColor(colors)
+        setPadding(
             BUTTON_HORIZONTAL_PADDING,
             BUTTON_VERTICAL_PADDING,
             BUTTON_HORIZONTAL_PADDING,
             BUTTON_VERTICAL_PADDING
         )
-        return view
     }
 
     private fun setupConstraint() {

--- a/app/src/main/java/com/abloom/mery/presentation/common/view/MeryAppBar.kt
+++ b/app/src/main/java/com/abloom/mery/presentation/common/view/MeryAppBar.kt
@@ -1,0 +1,10 @@
+package com.abloom.mery.presentation.common.view
+
+import android.content.Context
+import android.util.AttributeSet
+import androidx.constraintlayout.widget.ConstraintLayout
+
+class MeryAppBar @JvmOverloads constructor(
+    context: Context,
+    attrs: AttributeSet? = null,
+) : ConstraintLayout(context, attrs)

--- a/app/src/main/java/com/abloom/mery/presentation/common/view/MeryAppBar.kt
+++ b/app/src/main/java/com/abloom/mery/presentation/common/view/MeryAppBar.kt
@@ -13,8 +13,10 @@ import androidx.constraintlayout.widget.ConstraintSet
 import androidx.core.content.ContextCompat
 import androidx.core.content.res.ResourcesCompat
 import androidx.core.content.res.use
+import androidx.databinding.BindingAdapter
 import com.abloom.mery.R
 import com.abloom.mery.presentation.common.util.dp
+import kotlin.properties.Delegates.observable
 
 class MeryAppBar(
     context: Context,
@@ -24,6 +26,10 @@ class MeryAppBar(
     private lateinit var navigation: View
     private var title: View? = null
     private var action: View? = null
+
+    var isActionEnabled: Boolean by observable(true) { _, _, newValue ->
+        action?.isEnabled = newValue
+    }
 
     init {
         setupView()
@@ -162,4 +168,9 @@ class MeryAppBar(
         private val BUTTON_HORIZONTAL_PADDING = 4.dp
         private val BUTTON_VERTICAL_PADDING = 5.dp
     }
+}
+
+@BindingAdapter("app:isActionEnabled")
+fun MeryAppBar.setActionEnabled(enabled: Boolean) {
+    isActionEnabled = enabled
 }

--- a/app/src/main/java/com/abloom/mery/presentation/common/view/MeryAppBar.kt
+++ b/app/src/main/java/com/abloom/mery/presentation/common/view/MeryAppBar.kt
@@ -6,6 +6,7 @@ import android.graphics.Color
 import android.graphics.drawable.Drawable
 import android.util.AttributeSet
 import android.view.View
+import android.view.View.OnClickListener
 import android.widget.ImageView
 import android.widget.TextView
 import androidx.constraintlayout.widget.ConstraintLayout
@@ -29,6 +30,14 @@ class MeryAppBar(
 
     var isActionEnabled: Boolean by observable(true) { _, _, newValue ->
         action?.isEnabled = newValue
+    }
+
+    var onNavigationClickListener: OnClickListener? by observable(null) { _, _, newValue ->
+        navigation.setOnClickListener(newValue)
+    }
+
+    var onActionClickListener: OnClickListener? by observable(null) { _, _, newValue ->
+        action?.setOnClickListener(newValue)
     }
 
     init {
@@ -173,4 +182,14 @@ class MeryAppBar(
 @BindingAdapter("app:isActionEnabled")
 fun MeryAppBar.setActionEnabled(enabled: Boolean) {
     isActionEnabled = enabled
+}
+
+@BindingAdapter("app:onNavigationClick")
+fun MeryAppBar.setOnNavigationClick(onClickListener: OnClickListener) {
+    onNavigationClickListener = onClickListener
+}
+
+@BindingAdapter("app:onActionClick")
+fun MeryAppBar.setOnActionClick(onClickListener: OnClickListener) {
+    onActionClickListener = onClickListener
 }

--- a/app/src/main/java/com/abloom/mery/presentation/common/view/MeryAppBar.kt
+++ b/app/src/main/java/com/abloom/mery/presentation/common/view/MeryAppBar.kt
@@ -1,10 +1,165 @@
 package com.abloom.mery.presentation.common.view
 
 import android.content.Context
+import android.content.res.TypedArray
+import android.graphics.Color
+import android.graphics.drawable.Drawable
 import android.util.AttributeSet
+import android.view.View
+import android.widget.ImageView
+import android.widget.TextView
 import androidx.constraintlayout.widget.ConstraintLayout
+import androidx.constraintlayout.widget.ConstraintSet
+import androidx.core.content.ContextCompat
+import androidx.core.content.res.ResourcesCompat
+import androidx.core.content.res.use
+import com.abloom.mery.R
+import com.abloom.mery.presentation.common.util.dp
 
-class MeryAppBar @JvmOverloads constructor(
+class MeryAppBar(
     context: Context,
-    attrs: AttributeSet? = null,
-) : ConstraintLayout(context, attrs)
+    attrs: AttributeSet,
+) : ConstraintLayout(context, attrs) {
+
+    private lateinit var navigation: View
+    private var title: View? = null
+    private var action: View? = null
+
+    init {
+        setupView()
+        setupChildViews(attrs)
+        setupConstraint()
+    }
+
+    private fun setupView() {
+        minHeight = APP_BAR_HEIGHT
+        maxHeight = APP_BAR_HEIGHT
+        setPadding(APP_BAR_HORIZONTAL_PADDING, 0, APP_BAR_HORIZONTAL_PADDING, 0)
+    }
+
+    private fun setupChildViews(attrs: AttributeSet) {
+        context.obtainStyledAttributes(
+            attrs,
+            R.styleable.MeryAppBar,
+            0,
+            0
+        ).use { typedArray ->
+            setupNavigation(typedArray)
+
+            title = typedArray.getText(R.styleable.MeryAppBar_title)?.let { createTitleView(it) }
+
+            action = typedArray.getText(R.styleable.MeryAppBar_action)?.let { createActionView(it) }
+        }
+        addView(navigation)
+        addView(title)
+        addView(action)
+    }
+
+    private fun setupNavigation(typedArray: TypedArray) {
+        val navigationIcon = typedArray.getDrawable(R.styleable.MeryAppBar_navigationIcon)
+        val navigationText = typedArray.getText(R.styleable.MeryAppBar_navigationText)
+        require(!(navigationIcon != null && navigationText != null)) { "MeryAppBar의 navigationIcon과 navigationText 둘 중 하나만 사용할 수 있습니다." }
+        navigation = navigationIcon?.let { createNavigationIconView(it) }
+            ?: navigationText?.let { createNavigationTextView(it) }
+                    ?: throw IllegalArgumentException("MeryAppBar의 navigationIcon과 navigationText 둘 다 null이면 안됩니다.")
+    }
+
+    private fun createNavigationIconView(drawable: Drawable): ImageView {
+        val view = ImageView(context)
+        view.id = generateViewId()
+        view.layoutParams = LayoutParams(NAVIGATION_ICON_BUTTON_SIZE, NAVIGATION_ICON_BUTTON_SIZE)
+        view.setImageDrawable(drawable)
+        return view
+    }
+
+    private fun createNavigationTextView(text: CharSequence): TextView {
+        val view = TextView(context)
+        view.id = generateViewId()
+        view.text = text
+        view.setTextAppearance(R.style.callout)
+        view.typeface = ResourcesCompat.getFont(context, R.font.nanum_square_neo_bold)
+        val color = ContextCompat.getColor(context, R.color.primary_08)
+        view.setTextColor(color)
+        view.setPadding(
+            BUTTON_HORIZONTAL_PADDING,
+            BUTTON_VERTICAL_PADDING,
+            BUTTON_HORIZONTAL_PADDING,
+            BUTTON_VERTICAL_PADDING
+        )
+        return view
+    }
+
+    private fun createTitleView(text: CharSequence): TextView {
+        val view = TextView(context)
+        view.id = generateViewId()
+        view.text = text
+        view.setTextAppearance(R.style.body)
+        view.typeface = ResourcesCompat.getFont(context, R.font.nanum_square_neo_bold)
+        view.setTextColor(Color.BLACK)
+        return view
+    }
+
+    private fun createActionView(text: CharSequence): TextView {
+        val view = TextView(context)
+        view.id = generateViewId()
+        view.text = text
+        view.setTextAppearance(R.style.callout)
+        view.typeface = ResourcesCompat.getFont(context, R.font.nanum_square_neo_bold)
+        val colors = ContextCompat.getColorStateList(context, R.color.text_button)
+        view.setTextColor(colors)
+        view.setPadding(
+            BUTTON_HORIZONTAL_PADDING,
+            BUTTON_VERTICAL_PADDING,
+            BUTTON_HORIZONTAL_PADDING,
+            BUTTON_VERTICAL_PADDING
+        )
+        return view
+    }
+
+    private fun setupConstraint() {
+        val constraintSet = ConstraintSet()
+        constraintSet.clone(this)
+
+        constraintSet.setupNavigationConstraint()
+        constraintSet.setupTitleConstraint()
+        constraintSet.setupActionConstraint()
+
+        constraintSet.applyTo(this)
+    }
+
+    private fun ConstraintSet.setupNavigationConstraint() {
+        constrainWidth(navigation.id, ConstraintSet.WRAP_CONTENT)
+        constrainHeight(navigation.id, ConstraintSet.WRAP_CONTENT)
+        connect(navigation.id, ConstraintSet.START, ConstraintSet.PARENT_ID, ConstraintSet.START)
+        connect(navigation.id, ConstraintSet.TOP, ConstraintSet.PARENT_ID, ConstraintSet.TOP)
+        connect(navigation.id, ConstraintSet.BOTTOM, ConstraintSet.PARENT_ID, ConstraintSet.BOTTOM)
+    }
+
+    private fun ConstraintSet.setupTitleConstraint() {
+        val title = title ?: return
+        constrainWidth(title.id, ConstraintSet.WRAP_CONTENT)
+        constrainHeight(title.id, ConstraintSet.WRAP_CONTENT)
+        connect(title.id, ConstraintSet.START, ConstraintSet.PARENT_ID, ConstraintSet.START)
+        connect(title.id, ConstraintSet.END, ConstraintSet.PARENT_ID, ConstraintSet.END)
+        connect(title.id, ConstraintSet.TOP, ConstraintSet.PARENT_ID, ConstraintSet.TOP)
+        connect(title.id, ConstraintSet.BOTTOM, ConstraintSet.PARENT_ID, ConstraintSet.BOTTOM)
+    }
+
+    private fun ConstraintSet.setupActionConstraint() {
+        val action = action ?: return
+        constrainWidth(action.id, ConstraintSet.WRAP_CONTENT)
+        constrainHeight(action.id, ConstraintSet.WRAP_CONTENT)
+        connect(action.id, ConstraintSet.END, ConstraintSet.PARENT_ID, ConstraintSet.END)
+        connect(action.id, ConstraintSet.TOP, ConstraintSet.PARENT_ID, ConstraintSet.TOP)
+        connect(action.id, ConstraintSet.BOTTOM, ConstraintSet.PARENT_ID, ConstraintSet.BOTTOM)
+    }
+
+    companion object {
+
+        private val APP_BAR_HEIGHT = 56.dp
+        private val APP_BAR_HORIZONTAL_PADDING = 16.dp
+        private val NAVIGATION_ICON_BUTTON_SIZE = 22.dp
+        private val BUTTON_HORIZONTAL_PADDING = 4.dp
+        private val BUTTON_VERTICAL_PADDING = 5.dp
+    }
+}

--- a/app/src/main/res/color/text_button.xml
+++ b/app/src/main/res/color/text_button.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:color="@color/primary_08" android:state_enabled="true" />
+    <item android:color="@color/neutral_04" android:state_enabled="false" />
+</selector>

--- a/app/src/main/res/values/attrs.xml
+++ b/app/src/main/res/values/attrs.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <declare-styleable name="MeryAppBar">
+        <attr name="navigationIcon" format="reference" />
+        <attr name="navigationText" format="string" />
+        <attr name="title" format="string" />
+        <attr name="action" format="string" />
+    </declare-styleable>
+</resources>


### PR DESCRIPTION
#### close #24

### ✏️ 개요

홈 화면 빼고 모든 화면에서 사용될 앱 바 커스텀 뷰 구현

### 💻 작업 사항

앱 바를 커스텀 뷰로 구현했습니다.   
앱 바의 레이아웃은 ConstraintLayout 입니다.    
앱 바의 액션 버튼 활성화를 xml에서 동적으로 변경할 수 있게 바인딩 어댑터를 구현했습니다.    
바인딩 어댑터 사용을 위해 kapt 플러그인을 추가하였습니다.

### 📄 리뷰 노트

UI 레이어 틀을 구현하다가 한 번에 너무 많은 코드를 리뷰하려면 힘들기 때문에 나눠서 올립니다.

### 📱결과 화면(optional)

![image](https://github.com/abloom-AOS/MERY_Android/assets/123928686/555fcda5-48cd-4f09-8659-5b1ee25f33e8)

