### PR TITLE
[Fix/#46] GetAvailableQuestionsUseCase 수정

### DIFF
--- a/app/src/main/java/com/abloom/mery/presentation/ui/category/CategoryViewModel.kt
+++ b/app/src/main/java/com/abloom/mery/presentation/ui/category/CategoryViewModel.kt
@@ -26,7 +26,7 @@ class CategoryViewModel @Inject constructor(
             scope = viewModelScope
         )
 
-    val questions: StateFlow<Map<Category, Question>> = getAvailableQuestionsUseCase()
+    val questions: StateFlow<Map<Category, List<Question>>> = getAvailableQuestionsUseCase()
         .stateIn(
             initialValue = mapOf(),
             started = SharingStarted.WhileSubscribed(5_000),

--- a/domain/src/main/java/com/abloom/domain/question/usecase/GetAvailableQuestionsUseCase.kt
+++ b/domain/src/main/java/com/abloom/domain/question/usecase/GetAvailableQuestionsUseCase.kt
@@ -19,13 +19,13 @@ class GetAvailableQuestionsUseCase @Inject constructor(
      * Qna로 만들지 않은 질문만 사용가능합니다.
      */
     @OptIn(ExperimentalCoroutinesApi::class)
-    operator fun invoke(): Flow<Map<Category, Question>> =
+    operator fun invoke(): Flow<Map<Category, List<Question>>> =
         qnaRepository.getQnas().flatMapLatest { qnas ->
             val unavailableQuestionIds = qnas.map { it.question.id }.toSet()
 
             questionRepository.getQuestions().map { questions ->
                 questions.filter { question -> question.id !in unavailableQuestionIds }
-                    .associateBy { question -> question.category }
+                    .groupBy { question -> question.category }
             }
         }
 }


### PR DESCRIPTION
#### close #46

### ✏️ 개요

`GetAvailableQuestionsUseCase.invoke()` 메서드가 `Flow<Map<Category, Question>>` 대신 `Flow<Map<Category, List<Question>>>` 타입을 반환하도록 수정
