### PR TITLE
[Feat/#80] 가입화면 이동 로직 변경

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -7,6 +7,7 @@ plugins {
     alias(libs.plugins.ksp)
     alias(libs.plugins.googleServices)
     kotlin("kapt")
+    id("kotlin-parcelize")
     id("androidx.navigation.safeargs.kotlin")
 }
 

--- a/app/src/main/java/com/abloom/mery/presentation/ui/home/HomeEvent.kt
+++ b/app/src/main/java/com/abloom/mery/presentation/ui/home/HomeEvent.kt
@@ -1,5 +1,0 @@
-package com.abloom.mery.presentation.ui.home
-
-sealed interface HomeEvent {
-    data object LoginFail : HomeEvent
-}

--- a/app/src/main/java/com/abloom/mery/presentation/ui/home/HomeViewModel.kt
+++ b/app/src/main/java/com/abloom/mery/presentation/ui/home/HomeViewModel.kt
@@ -4,26 +4,19 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.abloom.domain.qna.model.Qna
 import com.abloom.domain.qna.usecase.GetQnasUseCase
-import com.abloom.domain.user.model.Authentication
 import com.abloom.domain.user.model.User
 import com.abloom.domain.user.usecase.GetLoginUserUseCase
-import com.abloom.domain.user.usecase.LoginUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
-import kotlinx.coroutines.flow.MutableSharedFlow
-import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
-import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @HiltViewModel
 class HomeViewModel @Inject constructor(
     getLoginUserUseCase: GetLoginUserUseCase,
     getQnasUseCase: GetQnasUseCase,
-    private val loginUseCase: LoginUseCase,
 ) : ViewModel() {
 
     val loginUser: StateFlow<User?> = getLoginUserUseCase()
@@ -45,12 +38,4 @@ class HomeViewModel @Inject constructor(
             started = SharingStarted.WhileSubscribed(5_000),
             scope = viewModelScope
         )
-
-    private val _event = MutableSharedFlow<HomeEvent>()
-    val event: SharedFlow<HomeEvent> = _event.asSharedFlow()
-
-    fun login(authentication: Authentication) = viewModelScope.launch {
-        val isLoginSuccess = loginUseCase(authentication)
-        if (!isLoginSuccess) _event.emit(HomeEvent.LoginFail)
-    }
 }

--- a/app/src/main/java/com/abloom/mery/presentation/ui/home/LoginEvent.kt
+++ b/app/src/main/java/com/abloom/mery/presentation/ui/home/LoginEvent.kt
@@ -1,0 +1,7 @@
+package com.abloom.mery.presentation.ui.home
+
+import com.abloom.domain.user.model.Authentication
+
+sealed interface LoginEvent {
+    data class LoginFail(val authentication: Authentication) : LoginEvent
+}

--- a/app/src/main/java/com/abloom/mery/presentation/ui/home/LoginViewModel.kt
+++ b/app/src/main/java/com/abloom/mery/presentation/ui/home/LoginViewModel.kt
@@ -1,0 +1,26 @@
+package com.abloom.mery.presentation.ui.home
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.abloom.domain.user.model.Authentication
+import com.abloom.domain.user.usecase.LoginUseCase
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+class LoginViewModel @Inject constructor(
+    private val loginUseCase: LoginUseCase,
+) : ViewModel() {
+
+    private val _event = MutableSharedFlow<LoginEvent>()
+    val event: SharedFlow<LoginEvent> = _event.asSharedFlow()
+
+    fun login(authentication: Authentication) = viewModelScope.launch {
+        val isLoginSuccess = loginUseCase(authentication)
+        if (!isLoginSuccess) _event.emit(LoginEvent.LoginFail(authentication))
+    }
+}

--- a/app/src/main/java/com/abloom/mery/presentation/ui/signup/AuthenticationArgs.kt
+++ b/app/src/main/java/com/abloom/mery/presentation/ui/signup/AuthenticationArgs.kt
@@ -1,0 +1,27 @@
+package com.abloom.mery.presentation.ui.signup
+
+import android.os.Parcelable
+import com.abloom.domain.user.model.Authentication
+import kotlinx.parcelize.Parcelize
+
+sealed interface AuthenticationArgs : Parcelable {
+
+    @Parcelize
+    data class Google(val token: String) : AuthenticationArgs {
+
+        override fun asAuthentication(): Authentication = Authentication.Google(token)
+    }
+
+    @Parcelize
+    data class Kakao(val email: String, val password: String) : AuthenticationArgs {
+
+        override fun asAuthentication(): Authentication = Authentication.Kakao(email, password)
+    }
+
+    fun asAuthentication(): Authentication
+}
+
+fun Authentication.asArgs(): AuthenticationArgs = when (this) {
+    is Authentication.Google -> AuthenticationArgs.Google(token)
+    is Authentication.Kakao -> AuthenticationArgs.Kakao(email, password)
+}

--- a/app/src/main/java/com/abloom/mery/presentation/ui/signup/PrivacyConsentFragment.kt
+++ b/app/src/main/java/com/abloom/mery/presentation/ui/signup/PrivacyConsentFragment.kt
@@ -4,7 +4,6 @@ import android.os.Bundle
 import android.view.View
 import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.findNavController
-import com.abloom.domain.user.model.Authentication
 import com.abloom.mery.R
 import com.abloom.mery.databinding.FragmentPrivacyConsentBinding
 import com.abloom.mery.presentation.common.base.BaseFragment
@@ -36,7 +35,7 @@ class PrivacyConsentFragment :
     }
 
     private fun handleSignUpButtonClick() {
-        viewModel.join(Authentication.Kakao("카카오 이메일", "패스워드"))
+        viewModel.join()
         findNavController().popBackStack()
     }
 }

--- a/app/src/main/java/com/abloom/mery/presentation/ui/signup/SignUpViewModel.kt
+++ b/app/src/main/java/com/abloom/mery/presentation/ui/signup/SignUpViewModel.kt
@@ -1,5 +1,6 @@
 package com.abloom.mery.presentation.ui.signup
 
+import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.abloom.domain.user.model.Authentication
@@ -18,8 +19,14 @@ import javax.inject.Inject
 
 @HiltViewModel
 class SignUpViewModel @Inject constructor(
+    savedStateHandle: SavedStateHandle,
     private val joinUseCase: JoinUseCase
 ) : ViewModel() {
+
+    private val authentication: Authentication = savedStateHandle
+        .get<AuthenticationArgs>("authentication")
+        ?.asAuthentication()
+        ?: throw IllegalArgumentException("회원가입 화면으로 이동할 때 AuthenticationArgs 인자를 넘기지 않았습니다.")
 
     private val _selectedSex = MutableStateFlow<Sex?>(null)
     val selectedSex = _selectedSex.asStateFlow()
@@ -70,7 +77,7 @@ class SignUpViewModel @Inject constructor(
         isPrivacyPolicyChecked.value = true
     }
 
-    fun join(authentication: Authentication) = viewModelScope.launch {
+    fun join() = viewModelScope.launch {
         val selectedSex = _selectedSex.value ?: return@launch
         joinUseCase(
             authentication = authentication,

--- a/app/src/main/res/navigation/app.xml
+++ b/app/src/main/res/navigation/app.xml
@@ -56,6 +56,9 @@
             app:exitAnim="@anim/nav_default_exit_anim"
             app:popEnterAnim="@anim/nav_default_pop_enter_anim"
             app:popExitAnim="@anim/slide_down" />
+        <argument
+            android:name="authentication"
+            app:argType="com.abloom.mery.presentation.ui.signup.AuthenticationArgs" />
     </fragment>
     <fragment
         android:id="@+id/webViewFragment"

--- a/domain/src/main/java/com/abloom/domain/user/model/Authentication.kt
+++ b/domain/src/main/java/com/abloom/domain/user/model/Authentication.kt
@@ -2,6 +2,5 @@ package com.abloom.domain.user.model
 
 sealed interface Authentication {
     data class Google(val token: String) : Authentication
-    data class Apple(val token: String) : Authentication
     data class Kakao(val email: String, val password: String) : Authentication
 }


### PR DESCRIPTION
#### close #80

### ✏️ 개요

가입화면으로 이동할 때 AuthenticationArgs 객체를 넘기도록 변경

### 💻 작업 사항

- 로그인 관련 로직을 HomeViewModel 대신 LoginViewModel에 옮김
- SignUpFragment로 이동할 때 인자를 담는 AuthenticationArgs 클래스 구현
- AuthenticationArgs 클래스를 파싱할 수 있도록 kotlin-parcelize 플러그인 추가
- Authentication 자식 클래스 중 Apple 클래스 제거

