### PR TITLE
[Fix/#93] repeatOnStarted 함수 수정

### DIFF
--- a/app/src/main/java/com/abloom/mery/presentation/MainActivity.kt
+++ b/app/src/main/java/com/abloom/mery/presentation/MainActivity.kt
@@ -18,11 +18,9 @@ import androidx.core.view.WindowCompat
 import androidx.core.view.WindowInsetsCompat
 import androidx.navigation.NavController
 import androidx.navigation.fragment.NavHostFragment
-import androidx.navigation.fragment.findNavController
 import com.abloom.mery.R
 import com.abloom.mery.databinding.ActivityMainBinding
-import com.abloom.mery.presentation.common.util.showToast
-import com.abloom.mery.presentation.ui.category.CategoryFragmentDirections
+import com.abloom.mery.presentation.common.extension.showToast
 import com.abloom.mery.presentation.ui.home.HomeFragmentDirections
 import com.google.firebase.messaging.FirebaseMessaging
 import dagger.hilt.android.AndroidEntryPoint

--- a/app/src/main/java/com/abloom/mery/presentation/common/bindingadapter/RecyclerViewBindingAdapter.kt
+++ b/app/src/main/java/com/abloom/mery/presentation/common/bindingadapter/RecyclerViewBindingAdapter.kt
@@ -6,7 +6,7 @@ import android.widget.LinearLayout
 import androidx.databinding.BindingAdapter
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
-import com.abloom.mery.presentation.common.util.dp
+import com.abloom.mery.presentation.common.extension.dp
 
 @BindingAdapter("app:itemSpacing_dp")
 fun RecyclerView.setItemSpacing(spacing: Int) {

--- a/app/src/main/java/com/abloom/mery/presentation/common/extension/ContextExt.kt
+++ b/app/src/main/java/com/abloom/mery/presentation/common/extension/ContextExt.kt
@@ -1,4 +1,4 @@
-package com.abloom.mery.presentation.common.util
+package com.abloom.mery.presentation.common.extension
 
 import android.content.ClipData
 import android.content.ClipboardManager

--- a/app/src/main/java/com/abloom/mery/presentation/common/extension/FragmentExt.kt
+++ b/app/src/main/java/com/abloom/mery/presentation/common/extension/FragmentExt.kt
@@ -1,5 +1,6 @@
-package com.abloom.mery.presentation.common.util
+package com.abloom.mery.presentation.common.extension
 
+import androidx.fragment.app.Fragment
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.lifecycleScope
@@ -7,8 +8,8 @@ import androidx.lifecycle.repeatOnLifecycle
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 
-fun LifecycleOwner.repeatOnStarted(block: suspend CoroutineScope.() -> Unit) {
+fun Fragment.repeatOnStarted(block: suspend CoroutineScope.() -> Unit) {
     lifecycleScope.launch {
-        lifecycle.repeatOnLifecycle(Lifecycle.State.STARTED, block)
+        viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED, block)
     }
 }

--- a/app/src/main/java/com/abloom/mery/presentation/common/extension/IntExt.kt
+++ b/app/src/main/java/com/abloom/mery/presentation/common/extension/IntExt.kt
@@ -1,4 +1,4 @@
-package com.abloom.mery.presentation.common.util
+package com.abloom.mery.presentation.common.extension
 
 import android.content.res.Resources
 import kotlin.math.roundToInt

--- a/app/src/main/java/com/abloom/mery/presentation/common/extension/ViewExt.kt
+++ b/app/src/main/java/com/abloom/mery/presentation/common/extension/ViewExt.kt
@@ -1,4 +1,4 @@
-package com.abloom.mery.presentation.common.util
+package com.abloom.mery.presentation.common.extension
 
 import android.view.View
 import android.view.inputmethod.InputMethodManager

--- a/app/src/main/java/com/abloom/mery/presentation/common/view/ConfirmDialog.kt
+++ b/app/src/main/java/com/abloom/mery/presentation/common/view/ConfirmDialog.kt
@@ -8,7 +8,7 @@ import android.os.Bundle
 import android.view.ViewGroup
 import com.abloom.mery.R
 import com.abloom.mery.databinding.DialogConfirmBinding
-import com.abloom.mery.presentation.common.util.dp
+import com.abloom.mery.presentation.common.extension.dp
 
 class ConfirmDialog(
     context: Context,

--- a/app/src/main/java/com/abloom/mery/presentation/common/view/InfoDialog.kt
+++ b/app/src/main/java/com/abloom/mery/presentation/common/view/InfoDialog.kt
@@ -8,7 +8,7 @@ import android.os.Bundle
 import android.view.ViewGroup
 import com.abloom.mery.R
 import com.abloom.mery.databinding.DialogInfoBinding
-import com.abloom.mery.presentation.common.util.dp
+import com.abloom.mery.presentation.common.extension.dp
 
 class InfoDialog(
     context: Context,

--- a/app/src/main/java/com/abloom/mery/presentation/common/view/MeryAppBar.kt
+++ b/app/src/main/java/com/abloom/mery/presentation/common/view/MeryAppBar.kt
@@ -16,7 +16,7 @@ import androidx.core.content.res.ResourcesCompat
 import androidx.core.content.res.use
 import androidx.databinding.BindingAdapter
 import com.abloom.mery.R
-import com.abloom.mery.presentation.common.util.dp
+import com.abloom.mery.presentation.common.extension.dp
 import kotlin.properties.Delegates.observable
 
 class MeryAppBar(

--- a/app/src/main/java/com/abloom/mery/presentation/ui/category/CategoryFragment.kt
+++ b/app/src/main/java/com/abloom/mery/presentation/ui/category/CategoryFragment.kt
@@ -14,7 +14,7 @@ import com.abloom.mery.R
 import com.abloom.mery.databinding.FragmentCategoryBinding
 import com.abloom.mery.presentation.MainViewModel
 import com.abloom.mery.presentation.common.base.BaseFragment
-import com.abloom.mery.presentation.common.util.repeatOnStarted
+import com.abloom.mery.presentation.common.extension.repeatOnStarted
 import com.abloom.mery.presentation.common.view.setOnNavigationClick
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.Dispatchers

--- a/app/src/main/java/com/abloom/mery/presentation/ui/connect/ConnectFragment.kt
+++ b/app/src/main/java/com/abloom/mery/presentation/ui/connect/ConnectFragment.kt
@@ -9,10 +9,10 @@ import androidx.navigation.fragment.findNavController
 import com.abloom.mery.R
 import com.abloom.mery.databinding.FragmentConnectBinding
 import com.abloom.mery.presentation.common.base.BaseFragment
-import com.abloom.mery.presentation.common.util.copyToClipboard
-import com.abloom.mery.presentation.common.util.hideSoftKeyboard
-import com.abloom.mery.presentation.common.util.repeatOnStarted
-import com.abloom.mery.presentation.common.util.showToast
+import com.abloom.mery.presentation.common.extension.copyToClipboard
+import com.abloom.mery.presentation.common.extension.hideSoftKeyboard
+import com.abloom.mery.presentation.common.extension.repeatOnStarted
+import com.abloom.mery.presentation.common.extension.showToast
 import com.abloom.mery.presentation.common.view.ConfirmDialog
 import com.abloom.mery.presentation.common.view.InfoDialog
 import com.abloom.mery.presentation.common.view.setOnNavigationClick

--- a/app/src/main/java/com/abloom/mery/presentation/ui/connect/KakaoShare.kt
+++ b/app/src/main/java/com/abloom/mery/presentation/ui/connect/KakaoShare.kt
@@ -3,7 +3,7 @@ package com.abloom.mery.presentation.ui.connect
 import android.content.ActivityNotFoundException
 import android.content.Context
 import com.abloom.mery.R
-import com.abloom.mery.presentation.common.util.showToast
+import com.abloom.mery.presentation.common.extension.showToast
 import com.kakao.sdk.common.util.KakaoCustomTabsClient
 import com.kakao.sdk.share.ShareClient
 import com.kakao.sdk.share.WebSharerClient

--- a/app/src/main/java/com/abloom/mery/presentation/ui/createqna/CreateQnaFragment.kt
+++ b/app/src/main/java/com/abloom/mery/presentation/ui/createqna/CreateQnaFragment.kt
@@ -9,7 +9,7 @@ import com.abloom.mery.R
 import com.abloom.mery.databinding.FragmentCreateQnaBinding
 import com.abloom.mery.presentation.MainViewModel
 import com.abloom.mery.presentation.common.base.BaseFragment
-import com.abloom.mery.presentation.common.util.repeatOnStarted
+import com.abloom.mery.presentation.common.extension.repeatOnStarted
 import com.abloom.mery.presentation.common.view.setOnNavigationClick
 import com.abloom.mery.presentation.ui.category.CategoryArgs
 import dagger.hilt.android.AndroidEntryPoint

--- a/app/src/main/java/com/abloom/mery/presentation/ui/home/HomeFragment.kt
+++ b/app/src/main/java/com/abloom/mery/presentation/ui/home/HomeFragment.kt
@@ -12,7 +12,7 @@ import com.abloom.mery.R
 import com.abloom.mery.databinding.FragmentHomeBinding
 import com.abloom.mery.presentation.MainViewModel
 import com.abloom.mery.presentation.common.base.BaseFragment
-import com.abloom.mery.presentation.common.util.repeatOnStarted
+import com.abloom.mery.presentation.common.extension.repeatOnStarted
 import com.abloom.mery.presentation.ui.home.qnasrecyclerview.QnaAdapter
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.flow.combine

--- a/app/src/main/java/com/abloom/mery/presentation/ui/home/LoginDialogFragment.kt
+++ b/app/src/main/java/com/abloom/mery/presentation/ui/home/LoginDialogFragment.kt
@@ -11,8 +11,8 @@ import com.abloom.domain.user.model.Authentication
 import com.abloom.mery.BuildConfig
 import com.abloom.mery.R
 import com.abloom.mery.databinding.FragmentLoginDialogBinding
-import com.abloom.mery.presentation.common.util.repeatOnStarted
-import com.abloom.mery.presentation.common.util.showToast
+import com.abloom.mery.presentation.common.extension.repeatOnStarted
+import com.abloom.mery.presentation.common.extension.showToast
 import com.abloom.mery.presentation.ui.signup.asArgs
 import com.google.android.gms.auth.api.signin.GoogleSignIn
 import com.google.android.gms.auth.api.signin.GoogleSignInClient

--- a/app/src/main/java/com/abloom/mery/presentation/ui/profilemenu/ProfileMenuFragment.kt
+++ b/app/src/main/java/com/abloom/mery/presentation/ui/profilemenu/ProfileMenuFragment.kt
@@ -13,7 +13,7 @@ import com.abloom.mery.R
 import com.abloom.mery.databinding.FragmentProfileMenuBinding
 import com.abloom.mery.presentation.MainViewModel
 import com.abloom.mery.presentation.common.base.BaseFragment
-import com.abloom.mery.presentation.common.util.repeatOnStarted
+import com.abloom.mery.presentation.common.extension.repeatOnStarted
 import com.abloom.mery.presentation.common.view.ConfirmDialog
 import com.abloom.mery.presentation.common.view.setOnNavigationClick
 import com.abloom.mery.presentation.ui.profilemenu.dialog.ProfileDetailMenuDialog

--- a/app/src/main/java/com/abloom/mery/presentation/ui/profilemenu/dialog/NameChangeDialog.kt
+++ b/app/src/main/java/com/abloom/mery/presentation/ui/profilemenu/dialog/NameChangeDialog.kt
@@ -9,7 +9,7 @@ import android.view.ViewGroup
 import androidx.fragment.app.DialogFragment
 import androidx.fragment.app.viewModels
 import com.abloom.mery.databinding.DialogNameChangeBinding
-import com.abloom.mery.presentation.common.util.dp
+import com.abloom.mery.presentation.common.extension.dp
 import com.abloom.mery.presentation.ui.profilemenu.ProfileMenuViewModel
 
 class NameChangeDialog : DialogFragment() {

--- a/app/src/main/java/com/abloom/mery/presentation/ui/profilemenu/dialog/marriagedatechange/MarriageDateChangeDialog.kt
+++ b/app/src/main/java/com/abloom/mery/presentation/ui/profilemenu/dialog/marriagedatechange/MarriageDateChangeDialog.kt
@@ -8,8 +8,8 @@ import android.widget.FrameLayout
 import androidx.core.view.setPadding
 import androidx.fragment.app.viewModels
 import com.abloom.mery.databinding.DialogMarriageDateChangeBinding
-import com.abloom.mery.presentation.common.util.dp
-import com.abloom.mery.presentation.common.util.repeatOnStarted
+import com.abloom.mery.presentation.common.extension.dp
+import com.abloom.mery.presentation.common.extension.repeatOnStarted
 import com.abloom.mery.presentation.ui.profilemenu.ProfileMenuViewModel
 import com.google.android.material.bottomsheet.BottomSheetBehavior
 import com.google.android.material.bottomsheet.BottomSheetDialogFragment

--- a/app/src/main/java/com/abloom/mery/presentation/ui/qna/QnaFragment.kt
+++ b/app/src/main/java/com/abloom/mery/presentation/ui/qna/QnaFragment.kt
@@ -17,7 +17,7 @@ import com.abloom.domain.qna.model.UnfinishedResponseQna
 import com.abloom.mery.R
 import com.abloom.mery.databinding.FragmentQnaBinding
 import com.abloom.mery.presentation.common.base.BaseFragment
-import com.abloom.mery.presentation.common.util.repeatOnStarted
+import com.abloom.mery.presentation.common.extension.repeatOnStarted
 import com.abloom.mery.presentation.common.view.setOnNavigationClick
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.flow.filterNotNull


### PR DESCRIPTION
#### close #93

### ✏️ 개요

repeatOnStarted 함수가 프래그먼트 안에서 쓰일 때는 viewLifecycleOwner가 STARTED가 되었을 때 실행되고 STOPPED가 되었을 때 그만둬야 합니다. 기존에는 lifecycle로 실행해서 Fragment가 다른 화면으로 navigate 했다가 다시 오면 다시 repeatOnStarted 함수가 실행되어서 collect를 불필요하게 여러 번 수행했습니다.

### 💻 작업 사항

lifecycle 대신 viewLifecycleOwner의 상태를 인식하도록 변경

