### PR TITLE
[Feat/#98] 구성 변경 대응

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -19,6 +19,7 @@
         <activity
             android:name=".presentation.MainActivity"
             android:exported="true"
+            android:configChanges="density|fontScale|fontWeightAdjustment|layoutDirection|locale|orientation|screenLayout|screenSize"
             android:theme="@style/Theme.App.Starting">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -18,9 +18,11 @@
         tools:targetApi="31">
         <activity
             android:name=".presentation.MainActivity"
-            android:exported="true"
             android:configChanges="density|fontScale|fontWeightAdjustment|layoutDirection|locale|orientation|screenLayout|screenSize"
-            android:theme="@style/Theme.App.Starting">
+            android:exported="true"
+            android:screenOrientation="portrait"
+            android:theme="@style/Theme.App.Starting"
+            tools:ignore="DiscouragedApi,LockedOrientationActivity">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 

--- a/app/src/main/java/com/abloom/mery/presentation/MainActivity.kt
+++ b/app/src/main/java/com/abloom/mery/presentation/MainActivity.kt
@@ -1,10 +1,13 @@
 package com.abloom.mery.presentation
 
 import android.Manifest
+import android.content.Context
 import android.content.pm.PackageManager
+import android.content.res.Configuration
 import android.graphics.Color
 import android.os.Build
 import android.os.Bundle
+import android.util.DisplayMetrics
 import android.util.Log
 import androidx.activity.addCallback
 import androidx.activity.enableEdgeToEdge
@@ -141,9 +144,18 @@ class MainActivity : AppCompatActivity() {
         }
     }
 
+    override fun attachBaseContext(newBase: Context) {
+        val newConfiguration = Configuration(newBase.resources.configuration)
+        newConfiguration.fontScale = FIXED_FONT_SCALE
+        newConfiguration.densityDpi = DisplayMetrics.DENSITY_420
+        applyOverrideConfiguration(newConfiguration)
+        super.attachBaseContext(newBase)
+    }
+
     companion object {
 
         private const val ASK_AGAIN_EXIT_DURATION = 2_000
+        private const val FIXED_FONT_SCALE = 1.0f
     }
 }
 


### PR DESCRIPTION
#### close #98

### ✏️ 개요

구성 변경에 대응

### 💻 작업 사항

- 시스템 크기와 텍스트 크기를 특정 값으로 제한
- 모든 구성 변경에도 액티비티가 재시작하지 않도록 구현
- 세로 모드로 제한
