### PR TITLE
[Fix/#107] 안전하게 화면 이동

### DIFF
--- a/app/src/main/java/com/abloom/mery/data/firebase/user/UserFirebaseDataSource.kt
+++ b/app/src/main/java/com/abloom/mery/data/firebase/user/UserFirebaseDataSource.kt
@@ -74,14 +74,6 @@ class UserFirebaseDataSource @Inject constructor(
             .set(userDocument)
     }
 
-    suspend fun getUserDocument(userId: String): UserDocument? = withContext(Dispatchers.IO) {
-        db.collection(COLLECTIONS_USER)
-            .document(userId)
-            .get()
-            .await()
-            .toObject(UserDocument::class.java)
-    }
-
     fun getUserDocumentFlow(userId: String): Flow<UserDocument?> =
         db.collection(COLLECTIONS_USER)
             .document(userId)

--- a/app/src/main/java/com/abloom/mery/presentation/ui/connect/ConnectFragment.kt
+++ b/app/src/main/java/com/abloom/mery/presentation/ui/connect/ConnectFragment.kt
@@ -8,7 +8,7 @@ import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.findNavController
 import com.abloom.mery.R
 import com.abloom.mery.databinding.FragmentConnectBinding
-import com.abloom.mery.presentation.common.base.BaseFragment
+import com.abloom.mery.presentation.common.base.NavigationFragment
 import com.abloom.mery.presentation.common.extension.copyToClipboard
 import com.abloom.mery.presentation.common.extension.hideSoftKeyboard
 import com.abloom.mery.presentation.common.extension.repeatOnStarted
@@ -19,7 +19,7 @@ import com.abloom.mery.presentation.common.view.setOnNavigationClick
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
-class ConnectFragment : BaseFragment<FragmentConnectBinding>(R.layout.fragment_connect) {
+class ConnectFragment : NavigationFragment<FragmentConnectBinding>(R.layout.fragment_connect) {
 
     private val viewModel: ConnectViewModel by viewModels()
 

--- a/app/src/main/java/com/abloom/mery/presentation/ui/home/HomeFragment.kt
+++ b/app/src/main/java/com/abloom/mery/presentation/ui/home/HomeFragment.kt
@@ -28,7 +28,7 @@ class HomeFragment : NavigationFragment<FragmentHomeBinding>(R.layout.fragment_h
     private val qnaAdapter: QnaAdapter by lazy { QnaAdapter(onQnaClick = ::navigateToQna) }
 
     private fun navigateToQna(questionId: Long) {
-        findNavController().navigate(
+        findNavController().navigateSafely(
             HomeFragmentDirections.actionHomeFragmentToQnaFragment(questionId)
         )
     }
@@ -56,11 +56,11 @@ class HomeFragment : NavigationFragment<FragmentHomeBinding>(R.layout.fragment_h
     }
 
     private fun navigateToProfileMenu() {
-        findNavController().navigate(HomeFragmentDirections.actionHomeFragmentToProfileMenuFragment())
+        findNavController().navigateSafely(HomeFragmentDirections.actionHomeFragmentToProfileMenuFragment())
     }
 
     private fun navigateToCreateQna() {
-        findNavController().navigate(HomeFragmentDirections.actionHomeFragmentToCreateQna())
+        findNavController().navigateSafely(HomeFragmentDirections.actionHomeFragmentToCreateQna())
     }
 
     private fun observeLoginEvent() {

--- a/app/src/main/java/com/abloom/mery/presentation/ui/leave/LeaveFragment.kt
+++ b/app/src/main/java/com/abloom/mery/presentation/ui/leave/LeaveFragment.kt
@@ -6,12 +6,12 @@ import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.findNavController
 import com.abloom.mery.R
 import com.abloom.mery.databinding.FragmentLeaveBinding
-import com.abloom.mery.presentation.common.base.BaseFragment
+import com.abloom.mery.presentation.common.base.NavigationFragment
 import com.abloom.mery.presentation.common.view.ConfirmDialog
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
-class LeaveFragment : BaseFragment<FragmentLeaveBinding>(R.layout.fragment_leave) {
+class LeaveFragment : NavigationFragment<FragmentLeaveBinding>(R.layout.fragment_leave) {
 
     private val viewModel: LeaveViewModel by viewModels()
 

--- a/app/src/main/java/com/abloom/mery/presentation/ui/profilemenu/ProfileMenuFragment.kt
+++ b/app/src/main/java/com/abloom/mery/presentation/ui/profilemenu/ProfileMenuFragment.kt
@@ -12,7 +12,7 @@ import com.abloom.domain.user.model.User
 import com.abloom.mery.R
 import com.abloom.mery.databinding.FragmentProfileMenuBinding
 import com.abloom.mery.presentation.MainViewModel
-import com.abloom.mery.presentation.common.base.BaseFragment
+import com.abloom.mery.presentation.common.base.NavigationFragment
 import com.abloom.mery.presentation.common.extension.repeatOnStarted
 import com.abloom.mery.presentation.common.view.ConfirmDialog
 import com.abloom.mery.presentation.common.view.setOnNavigationClick
@@ -22,7 +22,7 @@ import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
 class ProfileMenuFragment :
-    BaseFragment<FragmentProfileMenuBinding>(R.layout.fragment_profile_menu) {
+    NavigationFragment<FragmentProfileMenuBinding>(R.layout.fragment_profile_menu) {
 
     private val mainViewModel: MainViewModel by activityViewModels()
     private val profileMenuViewModel: ProfileMenuViewModel by viewModels()
@@ -78,18 +78,18 @@ class ProfileMenuFragment :
     }
 
     private fun navigateToConnect() {
-        findNavController().navigate(ProfileMenuFragmentDirections.actionProfileMenuFragmentToConnectFragment())
+        findNavController().navigateSafely(ProfileMenuFragmentDirections.actionProfileMenuFragmentToConnectFragment())
     }
 
     private fun navigateToWebView(url: WebViewUrl) {
-        findNavController().navigate(
+        findNavController().navigateSafely(
             ProfileMenuFragmentDirections
                 .actionProfileMenuFragmentToWebViewFromProfileMenuFragment(url)
         )
     }
 
     private fun navigateToLeave() {
-        findNavController().navigate(ProfileMenuFragmentDirections.actionProfileMenuFragmentToLeaveFragment())
+        findNavController().navigateSafely(ProfileMenuFragmentDirections.actionProfileMenuFragmentToLeaveFragment())
     }
 
     private fun showLogoutConfirmDialog() {
@@ -180,7 +180,7 @@ class ProfileMenuFragment :
                 }
 
                 LoginUserDescriptionUiState.NotConnected ->
-                    findNavController().navigate(ProfileMenuFragmentDirections.actionProfileMenuFragmentToConnectFragment())
+                    findNavController().navigateSafely(ProfileMenuFragmentDirections.actionProfileMenuFragmentToConnectFragment())
 
                 is LoginUserDescriptionUiState.Fiance -> {}
             }

--- a/app/src/main/java/com/abloom/mery/presentation/ui/qna/QnaFragment.kt
+++ b/app/src/main/java/com/abloom/mery/presentation/ui/qna/QnaFragment.kt
@@ -16,14 +16,14 @@ import com.abloom.domain.qna.model.UnfinishedAnswerQna
 import com.abloom.domain.qna.model.UnfinishedResponseQna
 import com.abloom.mery.R
 import com.abloom.mery.databinding.FragmentQnaBinding
-import com.abloom.mery.presentation.common.base.BaseFragment
+import com.abloom.mery.presentation.common.base.NavigationFragment
 import com.abloom.mery.presentation.common.extension.repeatOnStarted
 import com.abloom.mery.presentation.common.view.setOnNavigationClick
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.flow.filterNotNull
 
 @AndroidEntryPoint
-class QnaFragment : BaseFragment<FragmentQnaBinding>(R.layout.fragment_qna) {
+class QnaFragment : NavigationFragment<FragmentQnaBinding>(R.layout.fragment_qna) {
 
     private val viewModel: QnaViewModel by viewModels()
 
@@ -50,13 +50,13 @@ class QnaFragment : BaseFragment<FragmentQnaBinding>(R.layout.fragment_qna) {
 
     private fun navigateToWriteAnswer() {
         val questionId = viewModel.qna.value?.question?.id ?: return
-        findNavController().navigate(
+        findNavController().navigateSafely(
             QnaFragmentDirections.actionQnaFragmentToWriteAnswerFragment(questionId)
         )
     }
 
     private fun navigateToConnect() {
-        findNavController().navigate(QnaFragmentDirections.actionQnaFragmentToConnectFragment())
+        findNavController().navigateSafely(QnaFragmentDirections.actionQnaFragmentToConnectFragment())
     }
 
     private fun showResponseSelectDialog() {

--- a/app/src/main/java/com/abloom/mery/presentation/ui/signup/PrivacyConsentFragment.kt
+++ b/app/src/main/java/com/abloom/mery/presentation/ui/signup/PrivacyConsentFragment.kt
@@ -6,13 +6,13 @@ import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.findNavController
 import com.abloom.mery.R
 import com.abloom.mery.databinding.FragmentPrivacyConsentBinding
-import com.abloom.mery.presentation.common.base.BaseFragment
+import com.abloom.mery.presentation.common.base.NavigationFragment
 import com.abloom.mery.presentation.ui.webview.WebViewUrl
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
 class PrivacyConsentFragment :
-    BaseFragment<FragmentPrivacyConsentBinding>(R.layout.fragment_privacy_consent) {
+    NavigationFragment<FragmentPrivacyConsentBinding>(R.layout.fragment_privacy_consent) {
 
     private val viewModel: SignUpViewModel by viewModels({ requireParentFragment() })
 
@@ -29,7 +29,7 @@ class PrivacyConsentFragment :
     }
 
     private fun navigateToWebView(url: WebViewUrl) {
-        findNavController().navigate(
+        findNavController().navigateSafely(
             SignUpFragmentDirections.actionSignUpFragmentToWebViewFragment(url)
         )
     }

--- a/app/src/main/java/com/abloom/mery/presentation/ui/signup/SignUpFragment.kt
+++ b/app/src/main/java/com/abloom/mery/presentation/ui/signup/SignUpFragment.kt
@@ -12,13 +12,13 @@ import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.findNavController
 import com.abloom.mery.R
 import com.abloom.mery.databinding.FragmentSignUpBinding
-import com.abloom.mery.presentation.common.base.BaseFragment
+import com.abloom.mery.presentation.common.base.NavigationFragment
 import com.abloom.mery.presentation.common.view.setOnActionClick
 import com.abloom.mery.presentation.common.view.setOnNavigationClick
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
-class SignUpFragment : BaseFragment<FragmentSignUpBinding>(R.layout.fragment_sign_up) {
+class SignUpFragment : NavigationFragment<FragmentSignUpBinding>(R.layout.fragment_sign_up) {
 
     private val signUpViewModel: SignUpViewModel by viewModels()
 

--- a/app/src/main/java/com/abloom/mery/presentation/ui/splash/SplashFragment.kt
+++ b/app/src/main/java/com/abloom/mery/presentation/ui/splash/SplashFragment.kt
@@ -6,11 +6,11 @@ import androidx.lifecycle.lifecycleScope
 import androidx.navigation.fragment.findNavController
 import com.abloom.mery.R
 import com.abloom.mery.databinding.FragmentSplashBinding
-import com.abloom.mery.presentation.common.base.BaseFragment
+import com.abloom.mery.presentation.common.base.NavigationFragment
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 
-class SplashFragment : BaseFragment<FragmentSplashBinding>(R.layout.fragment_splash) {
+class SplashFragment : NavigationFragment<FragmentSplashBinding>(R.layout.fragment_splash) {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
@@ -21,7 +21,7 @@ class SplashFragment : BaseFragment<FragmentSplashBinding>(R.layout.fragment_spl
     private fun navigateToHomeLazily() {
         lifecycleScope.launch {
             delay(SPLASH_DURATION)
-            findNavController().navigate(SplashFragmentDirections.actionSplashFragmentToHomeFragment())
+            findNavController().navigateSafely(SplashFragmentDirections.actionSplashFragmentToHomeFragment())
         }
     }
 

--- a/app/src/main/java/com/abloom/mery/presentation/ui/webview/WebViewFragment.kt
+++ b/app/src/main/java/com/abloom/mery/presentation/ui/webview/WebViewFragment.kt
@@ -8,12 +8,12 @@ import androidx.navigation.fragment.findNavController
 import androidx.navigation.fragment.navArgs
 import com.abloom.mery.R
 import com.abloom.mery.databinding.FragmentWebViewBinding
-import com.abloom.mery.presentation.common.base.BaseFragment
+import com.abloom.mery.presentation.common.base.NavigationFragment
 import com.abloom.mery.presentation.common.view.setOnActionClick
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
-class WebViewFragment : BaseFragment<FragmentWebViewBinding>(R.layout.fragment_web_view) {
+class WebViewFragment : NavigationFragment<FragmentWebViewBinding>(R.layout.fragment_web_view) {
 
     private val args: WebViewFragmentArgs by navArgs()
 

--- a/app/src/main/java/com/abloom/mery/presentation/ui/writeanswer/WriteAnswerFragment.kt
+++ b/app/src/main/java/com/abloom/mery/presentation/ui/writeanswer/WriteAnswerFragment.kt
@@ -9,7 +9,7 @@ import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.findNavController
 import com.abloom.mery.R
 import com.abloom.mery.databinding.FragmentWriteAnswerBinding
-import com.abloom.mery.presentation.common.base.BaseFragment
+import com.abloom.mery.presentation.common.base.NavigationFragment
 import com.abloom.mery.presentation.common.view.ConfirmDialog
 import com.abloom.mery.presentation.common.view.setOnActionClick
 import com.abloom.mery.presentation.common.view.setOnNavigationClick
@@ -17,7 +17,7 @@ import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
 class WriteAnswerFragment :
-    BaseFragment<FragmentWriteAnswerBinding>(R.layout.fragment_write_answer) {
+    NavigationFragment<FragmentWriteAnswerBinding>(R.layout.fragment_write_answer) {
 
     private val writeAnswerViewModel: WriteAnswerViewModel by viewModels()
 


### PR DESCRIPTION
### close #107

### ✏️ 개요

다른 화면으로 이동하는 버튼을 빠르게 동시에 클릭하면 에러가 발생하는 문제를 해결

### 💻 작업 사항

다른 화면으로 이동할 수 있는 모든 Fragment가 NavigationFragment를 상속하도록 하고 navigate() 함수 대신 navigateSafely() 함수를 사용하도록 변경
