### PR TITLE
[Fix/#109] 다이얼로그와 앱바 크기 고정

### DIFF
--- a/app/src/main/java/com/abloom/mery/presentation/MainActivity.kt
+++ b/app/src/main/java/com/abloom/mery/presentation/MainActivity.kt
@@ -162,6 +162,7 @@ class MainActivity : AppCompatActivity() {
         private const val CHANNEL_NAME = "channel_name_mery"
         private const val ASK_AGAIN_EXIT_DURATION = 2_000
         private const val FIXED_FONT_SCALE = 1.0f
+        const val FIXED_DENSITY = 2.625f
     }
 }
 

--- a/app/src/main/java/com/abloom/mery/presentation/common/extension/IntExt.kt
+++ b/app/src/main/java/com/abloom/mery/presentation/common/extension/IntExt.kt
@@ -1,7 +1,9 @@
 package com.abloom.mery.presentation.common.extension
 
-import android.content.res.Resources
+import com.abloom.mery.presentation.MainActivity.Companion.FIXED_DENSITY
 import kotlin.math.roundToInt
 
 val Int.dp: Int
-    get() = (this * Resources.getSystem().displayMetrics.density).roundToInt()
+    get() {
+        return (this * FIXED_DENSITY).roundToInt()
+    }


### PR DESCRIPTION
#### close #109

### ✏️ 개요

다이얼로그와 앱바가 시스템 크기에 영향 받는 버그 해결

### 💻 작업 사항

IntExt 파일의 dp 확장 변수에서 시스템 크기에 영향 받지 않게 고정값을 사용하도록 수정

### 📱결과 화면(optional)

|  |  |
|--|--|
|![image](https://github.com/abloom-AOS/MERY_Android/assets/123928686/2af631b9-8ca5-470a-819a-ae99dd607ba3)|![image](https://github.com/abloom-AOS/MERY_Android/assets/123928686/fbccde95-ac9b-4da3-8329-0ab5ba907592)|


