### PR TITLE
[Feat/#117] 회원 탈퇴 시 답변 삭제

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -40,7 +40,8 @@ android {
 
     buildTypes {
         release {
-            isMinifyEnabled = false
+            isMinifyEnabled = true
+            isShrinkResources = true
             proguardFiles(
                 getDefaultProguardFile("proguard-android-optimize.txt"),
                 "proguard-rules.pro"

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -28,7 +28,7 @@ android {
         minSdk = 26
         targetSdk = 34
         versionCode = 1
-        versionName = "1.0"
+        versionName = "1.0.0"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
 

--- a/app/src/main/java/com/abloom/mery/MeryFirebaseMessagingService.kt
+++ b/app/src/main/java/com/abloom/mery/MeryFirebaseMessagingService.kt
@@ -28,6 +28,6 @@ class MeryFirebaseMessagingService : FirebaseMessagingService() {
 
     companion object {
 
-        private const val KEY_QUESTION_ID = "qid"
+        const val KEY_QUESTION_ID = "qid"
     }
 }

--- a/app/src/main/java/com/abloom/mery/data/firebase/qna/QnaFirebaseDataSource.kt
+++ b/app/src/main/java/com/abloom/mery/data/firebase/qna/QnaFirebaseDataSource.kt
@@ -1,8 +1,10 @@
 package com.abloom.mery.data.firebase.qna
 
 import com.google.firebase.firestore.FirebaseFirestore
+import com.google.firebase.firestore.QuerySnapshot
 import com.google.firebase.firestore.snapshots
 import com.google.firebase.firestore.toObject
+import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.flow.Flow
@@ -41,28 +43,45 @@ class QnaFirebaseDataSource @Inject constructor(
     }
 
     suspend fun updateReaction(
-        userId: String,
+        loginUserId: String,
         fianceId: String,
         questionId: Long,
         reaction: Int
     ) = withContext(Dispatchers.IO) {
-        val loginUserQnaQueryAsync = getQnaDocumentAsync(userId, questionId)
+        val loginUserQnaQueryAsync = getQnaDocumentAsync(loginUserId, questionId)
         val fianceQnaQueryAsync = getQnaDocumentAsync(fianceId, questionId)
 
         val (loginUserQnaQuerySnapshot, fianceQnaQuerySnapshot) =
             awaitAll(loginUserQnaQueryAsync, fianceQnaQueryAsync)
 
-        val loginUserQnaDocumentSnapshot = loginUserQnaQuerySnapshot.firstOrNull()
-            ?: return@withContext
-        val fianceQnaDocumentSnapshot = fianceQnaQuerySnapshot.firstOrNull()
-            ?: return@withContext
+        val loginUserAnswerId = loginUserQnaQuerySnapshot.firstOrNull()?.id ?: return@withContext
+        val fianceAnswerId = fianceQnaQuerySnapshot.firstOrNull()?.id ?: return@withContext
 
-        val isComplete = fianceQnaDocumentSnapshot.toObject<QnaDocument>().reaction != null
+        val loginUserAnswerRef = db.collection(COLLECTIONS_USER).document(loginUserId)
+            .collection(COLLECTIONS_ANSWERS)
+            .document(loginUserAnswerId)
+        val fianceAnswerRef = db.collection(COLLECTIONS_USER).document(fianceId)
+            .collection(COLLECTIONS_ANSWERS)
+            .document(fianceAnswerId)
 
-        db.runBatch { batch ->
-            batch.update(loginUserQnaDocumentSnapshot.reference, QnaDocument.KEY_REACTION, reaction)
+        db.runTransaction { transaction ->
+            val fianceQnaDocument = transaction.get(fianceAnswerRef)
+                .toObject<QnaDocument>()
+                ?: return@runTransaction
+
+            val isComplete = fianceQnaDocument.reaction != null
+
+            transaction.update(
+                loginUserAnswerRef,
+                QnaDocument.KEY_REACTION,
+                reaction
+            )
             if (isComplete) {
-                batch.update(fianceQnaDocumentSnapshot.reference, QnaDocument.KEY_IS_COMPLETE, true)
+                transaction.update(
+                    fianceAnswerRef,
+                    QnaDocument.KEY_IS_COMPLETE,
+                    true
+                )
             }
         }
     }
@@ -70,7 +89,7 @@ class QnaFirebaseDataSource @Inject constructor(
     private fun getQnaDocumentAsync(
         userId: String,
         questionId: Long
-    ) = db.collection(COLLECTIONS_USER)
+    ): Deferred<QuerySnapshot> = db.collection(COLLECTIONS_USER)
         .document(userId)
         .collection(COLLECTIONS_ANSWERS)
         .whereEqualTo(QnaDocument.KEY_QUESTION_ID, questionId)

--- a/app/src/main/java/com/abloom/mery/data/firebase/user/UserFirebaseDataSource.kt
+++ b/app/src/main/java/com/abloom/mery/data/firebase/user/UserFirebaseDataSource.kt
@@ -84,12 +84,22 @@ class UserFirebaseDataSource @Inject constructor(
             }
             .flowOn(Dispatchers.IO)
 
-    suspend fun connect(user1Id: String, user2Id: String): Unit = withContext(Dispatchers.IO) {
+    suspend fun connect(user1Id: String, user2Id: String): Boolean = withContext(Dispatchers.IO) {
         val user1Ref = db.collection(COLLECTIONS_USER).document(user1Id)
         val user2Ref = db.collection(COLLECTIONS_USER).document(user2Id)
-        db.runBatch {
-            user1Ref.update(UserDocument.KEY_FIANCE, user2Id)
-            user2Ref.update(UserDocument.KEY_FIANCE, user1Id)
+        db.runTransaction { transaction ->
+            val user1Document = transaction.get(user1Ref)
+                .toObject<UserDocument>()
+                ?: return@runTransaction false
+            val user2Document = transaction.get(user2Ref)
+                .toObject<UserDocument>()
+                ?: return@runTransaction false
+
+            if (user1Document.fianceId != null || user2Document.fianceId != null) return@runTransaction false
+
+            transaction.update(user1Ref, UserDocument.KEY_FIANCE, user2Id)
+            transaction.update(user2Ref, UserDocument.KEY_FIANCE, user1Id)
+            true
         }.await()
     }
 

--- a/app/src/main/java/com/abloom/mery/data/repository/DefaultQnaRepository.kt
+++ b/app/src/main/java/com/abloom/mery/data/repository/DefaultQnaRepository.kt
@@ -174,7 +174,7 @@ class DefaultQnaRepository @Inject constructor(
         externalScope.launch {
             val loginUserId = userRepository.loginUserId ?: return@launch
             firebaseDataSource.updateReaction(
-                userId = loginUserId,
+                loginUserId = loginUserId,
                 fianceId = qna.fiance.id,
                 questionId = qna.question.id,
                 reaction = response.asReaction()

--- a/app/src/main/java/com/abloom/mery/data/repository/DefaultUserRepository.kt
+++ b/app/src/main/java/com/abloom/mery/data/repository/DefaultUserRepository.kt
@@ -98,16 +98,16 @@ class DefaultUserRepository @Inject constructor(
 
     override suspend fun getUserByInvitationCode(
         invitationCode: String
-    ): User? = withContext(Dispatchers.IO) {
-        firebaseDataSource.getUserDocumentByInvitationCode(invitationCode)
+    ): User? = firebaseDataSource.getUserDocumentByInvitationCode(invitationCode)
             ?.let(UserDocument::asExternal)
-    }
 
     override suspend fun connectWith(
         fiance: User
-    ) = externalScope.async {
-        firebaseDataSource.connect(loginUserId ?: return@async, fiance.id)
-    }.await()
+    ): Boolean {
+        val loginUserId = this.loginUserId ?: return false
+        return firebaseDataSource.connect(loginUserId, fiance.id)
+    }
+
 
     override suspend fun changeLoginUserName(name: String) = externalScope.launch {
         val loginUserId = firebaseDataSource.loginUserId ?: return@launch

--- a/app/src/main/java/com/abloom/mery/presentation/MainActivity.kt
+++ b/app/src/main/java/com/abloom/mery/presentation/MainActivity.kt
@@ -20,9 +20,11 @@ import androidx.core.view.WindowCompat
 import androidx.core.view.WindowInsetsCompat
 import androidx.navigation.NavController
 import androidx.navigation.fragment.NavHostFragment
+import com.abloom.mery.MeryFirebaseMessagingService
 import com.abloom.mery.R
 import com.abloom.mery.databinding.ActivityMainBinding
 import com.abloom.mery.presentation.common.extension.showToast
+import com.abloom.mery.presentation.ui.qna.QnaFragment
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
@@ -61,9 +63,11 @@ class MainActivity : AppCompatActivity() {
     }
 
     private fun handleDeepLink() {
-        val questionId = intent.extras?.getString("qid")?.toLong()
+        val questionId = intent.extras
+            ?.getString(MeryFirebaseMessagingService.KEY_QUESTION_ID)
+            ?.toLong()
         if (questionId != null) {
-            val args = Bundle().apply { putLong("question_id", questionId) }
+            val args = QnaFragment.createArguments(questionId)
             navController.navigate(R.id.qnaFragment, args)
         }
     }

--- a/app/src/main/java/com/abloom/mery/presentation/notification/Notification.kt
+++ b/app/src/main/java/com/abloom/mery/presentation/notification/Notification.kt
@@ -4,15 +4,16 @@ import android.app.Notification
 import android.app.NotificationManager
 import android.app.PendingIntent
 import android.content.Context
-import android.os.Bundle
 import androidx.core.app.NotificationCompat
 import androidx.navigation.NavDeepLinkBuilder
 import com.abloom.mery.R
+import com.abloom.mery.presentation.ui.qna.QnaFragment
+import com.abloom.mery.presentation.ui.writeanswer.WriteAnswerFragment
 
 private const val TODAY_QUESTION_NOTIFICATION_ID = 1
 
 fun Context.notifyTodayQuestion(questionId: Long) {
-    val args = Bundle().apply { putLong("question_id", questionId) }
+    val args = WriteAnswerFragment.createArguments(questionId)
     val intent = NavDeepLinkBuilder(this)
         .setGraph(R.navigation.app)
         .setDestination(R.id.writeAnswerFragment)
@@ -28,7 +29,7 @@ fun Context.notifyTodayQuestion(questionId: Long) {
 }
 
 fun Context.notifyFianceAction(title: String, body: String, questionId: Long) {
-    val args = Bundle().apply { putLong("question_id", questionId) }
+    val args = QnaFragment.createArguments(questionId)
     val intent = NavDeepLinkBuilder(applicationContext)
         .setGraph(R.navigation.app)
         .setDestination(R.id.qnaFragment)

--- a/app/src/main/java/com/abloom/mery/presentation/ui/qna/QnaFragment.kt
+++ b/app/src/main/java/com/abloom/mery/presentation/ui/qna/QnaFragment.kt
@@ -274,7 +274,8 @@ class QnaFragment : NavigationFragment<FragmentQnaBinding>(R.layout.fragment_qna
 
     companion object {
 
-        private const val KEY_QUESTION_ID = "question_id"
-        fun getArgs(questionId: Long) = Bundle().apply { putLong(KEY_QUESTION_ID, questionId) }
+        const val KEY_QUESTION_ID = "question_id"
+        fun createArguments(questionId: Long): Bundle =
+            Bundle().apply { putLong(KEY_QUESTION_ID, questionId) }
     }
 }

--- a/app/src/main/java/com/abloom/mery/presentation/ui/qna/QnaViewModel.kt
+++ b/app/src/main/java/com/abloom/mery/presentation/ui/qna/QnaViewModel.kt
@@ -29,7 +29,7 @@ class QnaViewModel @Inject constructor(
 
     @OptIn(ExperimentalCoroutinesApi::class)
     val qna: StateFlow<Qna?> = savedStateHandle
-        .getStateFlow("question_id", INVALID_QUESTION_ID)
+        .getStateFlow(QnaFragment.KEY_QUESTION_ID, INVALID_QUESTION_ID)
         .filter { it != INVALID_QUESTION_ID }
         .flatMapLatest { getQnaUseCase(it) }
         .stateIn(

--- a/app/src/main/java/com/abloom/mery/presentation/ui/writeanswer/WriteAnswerFragment.kt
+++ b/app/src/main/java/com/abloom/mery/presentation/ui/writeanswer/WriteAnswerFragment.kt
@@ -101,6 +101,13 @@ class WriteAnswerFragment :
     private fun setupDataBinding() {
         binding.viewModel = writeAnswerViewModel
     }
+
+    companion object {
+
+        const val KEY_QUESTION_ID = "question_id"
+        fun createArguments(questionId: Long): Bundle =
+            Bundle().apply { putLong(KEY_QUESTION_ID, questionId) }
+    }
 }
 
 

--- a/app/src/main/java/com/abloom/mery/presentation/ui/writeanswer/WriteAnswerViewModel.kt
+++ b/app/src/main/java/com/abloom/mery/presentation/ui/writeanswer/WriteAnswerViewModel.kt
@@ -27,7 +27,7 @@ class WriteAnswerViewModel @Inject constructor(
 
     @OptIn(ExperimentalCoroutinesApi::class)
     val question: StateFlow<Question?> = savedStateHandle
-        .getStateFlow("question_id", INVALID_QUESTION_ID)
+        .getStateFlow(WriteAnswerFragment.KEY_QUESTION_ID, INVALID_QUESTION_ID)
         .filter { it != INVALID_QUESTION_ID }
         .flatMapLatest { getQuestionUseCase(it) }
         .stateIn(

--- a/app/src/main/res/layout/fragment_sign_up.xml
+++ b/app/src/main/res/layout/fragment_sign_up.xml
@@ -10,45 +10,58 @@
             type="com.abloom.mery.presentation.ui.signup.SignUpViewModel" />
     </data>
 
-    <androidx.constraintlayout.widget.ConstraintLayout
+    <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:background="@drawable/bg_page"
+        android:orientation="vertical"
         tools:context=".presentation.ui.signup.SignUpFragment">
 
         <com.abloom.mery.presentation.common.view.MeryAppBar
             android:id="@+id/appbar_sign_up"
-            android:layout_width="0dp"
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
             app:isActionEnabled="@{!viewModel.name.blank}"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent" />
 
-        <ProgressBar
-            android:id="@+id/signup_progressBar"
-            style="@android:style/Widget.ProgressBar.Horizontal"
+        <ScrollView
+            android:id="@+id/sv_signup"
             android:layout_width="match_parent"
-            android:layout_height="6dp"
-            android:layout_marginStart="20dp"
-            android:layout_marginTop="62dp"
-            android:layout_marginEnd="20dp"
-            android:max="100"
-            android:progress="25"
-            android:progressDrawable="@drawable/progress_horizontal_custom"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent" />
+            android:layout_height="wrap_content">
 
-        <androidx.fragment.app.FragmentContainerView
-            android:id="@+id/fragmentContainerView"
-            android:layout_width="0dp"
-            android:layout_height="0dp"
-            app:layout_constraintBottom_toBottomOf="parent"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/signup_progressBar" />
+            <androidx.constraintlayout.widget.ConstraintLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content">
 
-    </androidx.constraintlayout.widget.ConstraintLayout>
+                <ProgressBar
+                    android:id="@+id/signup_progressBar"
+                    style="@android:style/Widget.ProgressBar.Horizontal"
+                    android:layout_width="match_parent"
+                    android:layout_height="6dp"
+                    android:layout_marginStart="20dp"
+                    android:layout_marginEnd="20dp"
+                    android:max="100"
+                    android:progress="25"
+                    android:progressDrawable="@drawable/progress_horizontal_custom"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toTopOf="parent" />
+
+                <androidx.fragment.app.FragmentContainerView
+                    android:id="@+id/fragmentContainerView"
+                    android:layout_width="match_parent"
+                    android:layout_height="match_parent"
+                    app:layout_constraintBottom_toBottomOf="parent"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintStart_toStartOf="parent"
+                    app:layout_constraintTop_toBottomOf="@id/signup_progressBar" />
+
+            </androidx.constraintlayout.widget.ConstraintLayout>
+
+        </ScrollView>
+
+    </LinearLayout>
 
 </layout>

--- a/domain/src/main/java/com/abloom/domain/user/repository/UserRepository.kt
+++ b/domain/src/main/java/com/abloom/domain/user/repository/UserRepository.kt
@@ -31,7 +31,7 @@ interface UserRepository {
 
     suspend fun getUserByInvitationCode(invitationCode: String): User?
 
-    suspend fun connectWith(fiance: User)
+    suspend fun connectWith(fiance: User): Boolean
 
     suspend fun changeLoginUserName(name: String)
 

--- a/domain/src/main/java/com/abloom/domain/user/usecase/ConnectWithFianceUseCase.kt
+++ b/domain/src/main/java/com/abloom/domain/user/usecase/ConnectWithFianceUseCase.kt
@@ -14,7 +14,6 @@ class ConnectWithFianceUseCase @Inject constructor(
         val loginUserId = userRepository.loginUserId
         val fiance = userRepository.getUserByInvitationCode(fianceInvitationCode) ?: return false
         if (fiance.isLinkedWithFiance || fiance.id == loginUserId) return false
-        userRepository.connectWith(fiance)
-        return true
+        return userRepository.connectWith(fiance)
     }
 }


### PR DESCRIPTION
#### close #117

### ✏️ 개요

- 회원 탈퇴 시 유저의 answers 컬렉션의 문서들도 삭제하도록 수정
- 버전명을 1.0.0으로 수정
- 두 유저 연결 기능을 트랜잭션화
- 반응 남기기 기능을 트랜잭션화
- 로그인 유저 조회 시 로컬 아이디와 firebase auth 아이디가 다를경우 에러 대신 null을 방출하는 flow를 반환하도록 수정
