### PR TITLE
[Bug/#137] 로그인 버그 고침

### DIFF
--- a/app/src/main/java/com/abloom/mery/data/firebase/user/UserDocument.kt
+++ b/app/src/main/java/com/abloom/mery/data/firebase/user/UserDocument.kt
@@ -25,13 +25,15 @@ class UserDocument(
         name: String,
         marriageDate: LocalDate,
         sex: Sex,
-        invitationCode: String
+        invitationCode: String,
+        fcmToken: String,
     ) : this(
         user_id = id,
         name = name,
         marriage_date = marriageDate.toTimestamp(),
         sex = sex == Sex.MALE,
-        invitation_code = invitationCode
+        invitation_code = invitationCode,
+        fcm_token = fcmToken,
     )
 
     fun asExternal() = User(

--- a/app/src/main/java/com/abloom/mery/data/firebase/user/UserFirebaseDataSource.kt
+++ b/app/src/main/java/com/abloom/mery/data/firebase/user/UserFirebaseDataSource.kt
@@ -4,7 +4,6 @@ import com.abloom.mery.data.firebase.documentFlow
 import com.abloom.mery.data.firebase.fetchDocument
 import com.abloom.mery.data.firebase.fetchDocuments
 import com.abloom.mery.data.firebase.toTimestamp
-import com.google.firebase.messaging.FirebaseMessaging
 import dev.gitlive.firebase.auth.FirebaseAuth
 import dev.gitlive.firebase.auth.FirebaseAuthInvalidCredentialsException
 import dev.gitlive.firebase.auth.FirebaseUser
@@ -22,7 +21,6 @@ import javax.inject.Inject
 class UserFirebaseDataSource @Inject constructor(
     private val auth: FirebaseAuth,
     private val db: FirebaseFirestore,
-    private val messaging: FirebaseMessaging
 ) {
 
     val loginUserId: String?
@@ -144,11 +142,12 @@ class UserFirebaseDataSource @Inject constructor(
         auth.currentUser?.delete()
     }
 
-    suspend fun loginUpdateFcmToken(userId: String) = withContext(Dispatchers.IO) {
-        db.collection(COLLECTIONS_USER)
-            .document(userId)
-            .update(UserDocument::fcm_token.name to messaging.token.result.toString())
-    }
+    suspend fun loginUpdateFcmToken(userId: String, fcmToken: String) =
+        withContext(Dispatchers.IO) {
+            db.collection(COLLECTIONS_USER)
+                .document(userId)
+                .update(UserDocument::fcm_token.name to fcmToken)
+        }
 
     suspend fun logOutUpdateFcmToken(userId: String) = withContext(Dispatchers.IO) {
         db.collection(COLLECTIONS_USER)


### PR DESCRIPTION
#### close #137

### ✏️ 개요

로그인 시 존재하지 않는 유저 문서를 수정하면 에러가 발생함.

### 💻 작업 사항

- 문서가 존재하지 않으면 곧바로 리턴하도록 수정
- fcmToken 조회할 때 `result` 대신 `await()`로 조회하도록 변경. `result`로 조회하면 가끔 작업이 완료되지 않았다는 에러가 발생하기 때문.