### PR TITLE
[Fix/#139] 기존의 회원 삭제 API를 호출하도록 수정

### DIFF
--- a/app/src/main/java/com/abloom/mery/data/firebase/user/UserFirebaseDataSource.kt
+++ b/app/src/main/java/com/abloom/mery/data/firebase/user/UserFirebaseDataSource.kt
@@ -139,7 +139,7 @@ class UserFirebaseDataSource @Inject constructor(
             answerDocumentRefs.forEach { delete(it) }
             delete(userRef)
         }
-        auth.currentUser?.delete()
+        auth.currentUser?.android?.delete()
     }
 
     suspend fun loginUpdateFcmToken(userId: String, fcmToken: String) =


### PR DESCRIPTION
#### close #139

### ✏️ 개요

로그인 후 어느 정도 시간이 지나서 회원 탈퇴하면 에러 발생   
Firebase Kotlin SDK에서는 인증한 후 어느 정도 시간이 지나면 민감한 작업(회원 탈퇴, 비밀번호 변경 등)을 수행 시 에러를 던집니다. [관련 링크](https://stackoverflow.com/questions/56617518/firebase-error-when-deleting-user-account-this-operation-is-sensitive-and-requi)    

### 💻 작업 사항

회원 삭제 API를 Firebase Kotlin SDK의 API 대신 기존의 API를 사용하도록 변경

